### PR TITLE
Proposed fix for FAIL reports by CPANTESTERS.

### DIFF
--- a/lib/Logic/TruthTable.pm
+++ b/lib/Logic/TruthTable.pm
@@ -611,7 +611,7 @@ sub fncolumn
 	#### Let's look an an element: $self->_fn_lookup()->{$fn_name}
 	#
 
-	$idx = %{$self->_fn_lookup()}{$fn_name};
+	$idx = $self->_fn_lookup()->{$fn_name};
 
 	return undef unless (defined $idx);
 	return ${$self->_get_columns}[$idx];


### PR DESCRIPTION
Hi @jgamble 

Please review the PR.
It tries to resolve the issue raised in the following reports.

https://www.cpantesters.org/cpan/report/f914306e-3411-11e9-a749-84781e6728e8
https://www.cpantesters.org/cpan/report/f379b55c-3411-11e9-a749-84781e6728e8
https://www.cpantesters.org/cpan/report/eeec3ce4-3411-11e9-a749-84781e6728e8
https://www.cpantesters.org/cpan/report/ea573148-3411-11e9-a749-84781e6728e8


    #   Failed test 'use Logic::TruthTable;'
    #   at t/00-load.t line 10.
    #     Tried to use 'Logic::TruthTable'.
    #     Error:  syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 614, near "}{"
    # Global symbol "$idx" requires explicit package name at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 616.
    # Global symbol "$self" requires explicit package name at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 617.
    # Global symbol "$idx" requires explicit package name at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 617.
    # syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 619, near "}"
    # syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 763, near "}"
    # syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 798, near "}"
    # syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 1044, near "}"
    # syntax error at /home/cpansand/.cpan/build/2019021823/Logic-TruthTable-1.01-1/blib/lib/Logic/TruthTable.pm line 1128, near "}"C

Many Thanks.
Best Regards,
Mohammad S Anwar